### PR TITLE
paths: whitelist /api/v1/labels

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 	listenAddr         = kingpin.Flag("proxy.listen-addr", "address the proxy will listen on").Required().String()
 
 	urlPattern           = regexp.MustCompile(`^/([^/]+)(/api/v.+)$`)
-	supportedPathPattern = regexp.MustCompile(`^/api/v1/(query|query_range|query_exemplars|series|label/[a-zA-Z0-9_]+/values)$`)
+	supportedPathPattern = regexp.MustCompile(`^/api/v1/(query|query_range|query_exemplars|series|labels|label/[a-zA-Z0-9_]+/values)$`)
 )
 
 func handleQuery(filter string, rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I think it's causing Grafana not to load variables from `label_values` query:
<img width="1425" alt="Screenshot 2025-03-26 at 16 47 31" src="https://github.com/user-attachments/assets/36aa62c8-fb3c-4e1a-92bc-bb037f16f74f" />
<img width="432" alt="Screenshot 2025-03-26 at 16 47 40" src="https://github.com/user-attachments/assets/b90980e6-bdf4-4a96-b75f-9e81fa7dafd9" />

```
❯ curl 0:9090/prometheus/api/v1/labels
Unsupported path
```